### PR TITLE
Add multi-tool agent framework

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,6 +248,28 @@ export const myTool = tool({
 });
 ```
 
+### Combining Tools with Multi-Tool Agents
+
+Tools register themselves with a simple registry. You can mix and match them by
+using the `multi` agent and specifying which tools to enable:
+
+```typescript
+import { tool } from 'ai';
+import { registerTool } from './server/src/tools/registry.js';
+
+export const myTool = tool({
+  /* ... */
+});
+
+registerTool('myTool', myTool);
+```
+
+Run the multi agent with your chosen tools:
+
+```bash
+ai run multi "What's the weather in Boston?" --tools weather
+```
+
 ## Architecture
 
 - **Agents** - Encapsulate specific AI behaviors and tool usage

--- a/server/src/agents/index.ts
+++ b/server/src/agents/index.ts
@@ -1,8 +1,10 @@
 import { LanguageModelV2 } from '@ai-sdk/provider';
 import { BaseAgent } from '../types/agent.js';
 import { WeatherAgent } from './weather-agent.js';
+import { MultiToolAgent } from './multi-tool-agent.js';
 
 export { WeatherAgent } from './weather-agent.js';
+export { MultiToolAgent } from './multi-tool-agent.js';
 export { BaseAgent } from '../types/agent.js';
 
 export type AgentConstructor = new (config: {
@@ -10,11 +12,13 @@ export type AgentConstructor = new (config: {
   description: string;
   model: LanguageModelV2;
   systemPrompt?: string;
+  tools?: string[];
 }) => BaseAgent;
 
 // Agent registry for dynamic agent creation
 export const agentRegistry: Record<string, AgentConstructor> = {
   weather: WeatherAgent,
+  multi: MultiToolAgent,
 };
 
 export function createAgent(
@@ -24,6 +28,7 @@ export function createAgent(
     name: string;
     description: string;
     systemPrompt: string;
+    tools: string[];
   }>
 ): BaseAgent {
   const AgentClass = agentRegistry[type];
@@ -38,6 +43,10 @@ export function createAgent(
       description: 'Provides current weather information for any location',
       systemPrompt: 'You are a helpful weather assistant. When asked about weather, use the weather tool to get current conditions. Be concise and friendly in your responses.',
     },
+    multi: {
+      name: 'MultiToolAgent',
+      description: 'Agent that can use a custom list of tools',
+    },
   };
 
   const defaultConfig = defaultConfigs[type as keyof typeof defaultConfigs] || {
@@ -49,5 +58,6 @@ export function createAgent(
     ...defaultConfig,
     ...customConfig,
     model,
+    tools: customConfig?.tools,
   });
 }

--- a/server/src/agents/multi-tool-agent.ts
+++ b/server/src/agents/multi-tool-agent.ts
@@ -1,0 +1,61 @@
+import { generateText, stepCountIs } from 'ai';
+import { BaseAgent, AgentContext, AgentResult, AgentConfig } from '../types/agent.js';
+import { getTools } from '../tools/registry.js';
+
+export interface MultiToolAgentConfig extends AgentConfig {
+  tools: string[];
+}
+
+export class MultiToolAgent extends BaseAgent {
+  private toolNames: string[];
+
+  constructor(config: MultiToolAgentConfig) {
+    super(config);
+    this.toolNames = config.tools;
+  }
+
+  async execute(context: AgentContext): Promise<AgentResult> {
+    const startTime = Date.now();
+    const stepLogs: Array<{ stepNumber: number; text: string; toolCalls: unknown[] }> = [];
+
+    try {
+      const tools = getTools(this.toolNames);
+
+      const stream = await generateText({
+        model: this.config.model,
+        tools,
+        toolChoice: 'auto',
+        system: this.config.systemPrompt ?? 'You are a helpful AI assistant.',
+        prompt: context.query,
+        stopWhen: [stepCountIs(3)],
+        onStepFinish: (step) => {
+          stepLogs.push({
+            stepNumber: stepLogs.length + 1,
+            text: step.text,
+            toolCalls: step.toolCalls,
+          });
+        },
+      });
+
+      const text = await stream.text;
+      const toolCalls = await stream.toolCalls;
+      const usage = await stream.usage;
+
+      return {
+        success: true,
+        data: { text, toolCalls, usage, steps: stepLogs },
+        metadata: {
+          toolCalls: toolCalls.length,
+          duration: Date.now() - startTime,
+          model: this.config.model.modelId,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+        metadata: { duration: Date.now() - startTime },
+      };
+    }
+  }
+}

--- a/server/src/cli/index.ts
+++ b/server/src/cli/index.ts
@@ -56,6 +56,7 @@ program
   .description('Run an agent with a query')
   .option('-p, --provider <provider>', 'LLM provider')
   .option('-m, --model <model>', 'Specific model to use or tier (small/default/large)')
+  .option('-t, --tools <tools>', 'Comma separated list of tools for multi agents')
   .option('--system <prompt>', 'Custom system prompt')
   .action(async (agentType: string, query: string, options) => {
     try {
@@ -69,8 +70,15 @@ program
       const model = ProviderFactory.getModel(provider, modelTier);
       
       // Create the agent
+      const toolNames = options.tools
+        ? String(options.tools)
+            .split(',')
+            .map((t: string) => t.trim())
+        : undefined;
+
       const agent = createAgent(agentType, model, {
         systemPrompt: options.system,
+        tools: toolNames,
       });
       
       console.log(`📝 Query: "${query}"`);

--- a/server/src/tools/index.ts
+++ b/server/src/tools/index.ts
@@ -1,1 +1,8 @@
 export * from './weather.js';
+export * from './registry.js';
+
+// Register built-in tools
+import { registerTool } from './registry.js';
+import { weatherTool } from './weather.js';
+
+registerTool('weather', weatherTool);

--- a/server/src/tools/registry.ts
+++ b/server/src/tools/registry.ts
@@ -1,0 +1,22 @@
+export type RegisteredTool = any;
+
+export const toolRegistry: Record<string, RegisteredTool> = {};
+
+export function registerTool(name: string, tool: RegisteredTool): void {
+  toolRegistry[name] = tool;
+}
+
+export function getTool(name: string): RegisteredTool | undefined {
+  return toolRegistry[name];
+}
+
+export function getTools(names: string[]): Record<string, RegisteredTool> {
+  const result: Record<string, RegisteredTool> = {};
+  for (const name of names) {
+    const t = getTool(name);
+    if (t) {
+      result[name] = t;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- support registering tools dynamically
- create `MultiToolAgent` that can call any set of tools
- add `--tools` flag to CLI run command
- document multi-tool usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: cannot find modules because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b6fbc8610832b9de64b6bff706ffb